### PR TITLE
[221228 김대현] 관리자 회원목록 검색기능 추가 검색시 페이징이 그대로 남아있어 행카운트 조금 수정

### DIFF
--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminUserController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminUserController.java
@@ -29,9 +29,11 @@ public class AdminUserController {
 	@SuppressWarnings("unchecked")
 	@GetMapping("/userList")
 	public String userList(Model model
-			 ,@RequestParam(value="currentPage", defaultValue = "1", required = false) int currentPage) {
+			 ,@RequestParam(value="currentPage", defaultValue = "1", required = false) int currentPage
+			 ,@RequestParam(value="searchKey", required = false) String searchKey
+			 ,@RequestParam(value="searchValue", required = false, defaultValue = "") String searchValue) {
 		
-		Map<String, Object> paramMap = adminUserService.userList(currentPage);
+		Map<String, Object> paramMap = adminUserService.userList(currentPage, searchKey, searchValue);
 		int lastPage = (int) paramMap.get("lastPage");
 		List<User> userList = (List<User>) paramMap.get("userList");
 		

--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/service/AdminUserService.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/service/AdminUserService.java
@@ -23,7 +23,25 @@ public class AdminUserService {
 	}
 	
 	// 회원 목록 + 페이징
-	public Map<String, Object> userList(int currentPage){
+	public Map<String, Object> userList(int currentPage, String searchKey, String searchValue){
+		
+		// 검색 
+		if(searchKey != null) {
+			switch (searchKey) {
+			case "userId":
+				searchKey = "u.user_id";
+				break;
+			case "userLevelName":
+				searchKey = "ul.user_level_name";
+				break;
+			case "userName":
+				searchKey = "u.user_name";
+				break;
+			case "userNickName":
+				searchKey = "u.user_nickname";
+				break;
+			}
+		}
 		
 		// 보여질 행의 갯수
 		int rowPerPage = 10;
@@ -33,7 +51,7 @@ public class AdminUserService {
 		
 		// 마지막페이지 
 		// 테이블의 전체 행의 갯수
-		double rowCnt = adminUserMapper.getUserListCnt();
+		double rowCnt = adminUserMapper.getUserListCnt(searchKey, searchValue);
 		// 마지막페이지
 		int lastPage = (int) Math.ceil(rowCnt/rowPerPage);
 		
@@ -42,10 +60,12 @@ public class AdminUserService {
 		int endPageNum = (int) Math.ceil(currentPage * 0.1) * 10;
 		int startPageNum = endPageNum - 10 + 1;
 		
+		// 이전버튼 : [11] ... [20]  -->  [1] ... [10]
 		int prevPage = (int) Math.floor(currentPage * 0.1) * 10;
 		if(currentPage % 10 == 0) {
 			prevPage = (int) Math.floor(currentPage * 0.1) * 10 - 10;
 		}
+		// 다음버튼 : [1] ... [10]  --> [11] ... [20]
 		int nextPage = (int) Math.ceil(currentPage * 0.1) * 10 + 1;
 		
 		if(endPageNum > lastPage) {
@@ -56,6 +76,8 @@ public class AdminUserService {
 		Map<String, Object> paramMap = new HashMap<String, Object>();
 		paramMap.put("startRowNum", startRowNum);
 		paramMap.put("rowPerPage", rowPerPage);
+		paramMap.put("searchKey", searchKey);
+		paramMap.put("searchValue", searchValue);
 		
 		// 유저목록 data
 		List<User> userList = adminUserMapper.userList(paramMap);

--- a/ks45team03/src/main/java/ks45team03/rentravel/mapper/AdminUserMapper.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/mapper/AdminUserMapper.java
@@ -10,18 +10,18 @@ import ks45team03.rentravel.dto.UserLevel;
 
 @Mapper
 public interface AdminUserMapper {
-	// 회원 목록
-			public List<User> userList(Map<String, Object> paramMap);
-			
-			// 테이블 행의 갯수
-			public int getUserListCnt();
-			
-			// 수정처리
-			public int modifyUser(User user);
-			
-			// 특정 회원 조회(수정)
-			public User getUserInfoById(String userId);		
-			
-			// 회원 등급 조회
-			public List<UserLevel> getUserLevelList();
+		// 회원 목록
+		public List<User> userList(Map<String, Object> paramMap);
+		
+		// 테이블 행의 갯수
+		public int getUserListCnt(String searchKey, String searchValue);
+		
+		// 수정처리
+		public int modifyUser(User user);
+		
+		// 특정 회원 조회(수정)
+		public User getUserInfoById(String userId);		
+		
+		// 회원 등급 조회
+		public List<UserLevel> getUserLevelList();
 }

--- a/ks45team03/src/main/resources/mapper/AdminUserMapper.xml
+++ b/ks45team03/src/main/resources/mapper/AdminUserMapper.xml
@@ -48,9 +48,14 @@
 			tb_region_sido AS si
 			ON 
 			sgg.region_sido_code = si.region_sido_code
-		<if test="startRowNum != null and startRowNum > -1">
-			LIMIT #{startRowNum}, #{rowPerPage};
-		</if>
+			<where>
+			<if test="searchKey != null and searchValue != ''">
+				${searchKey} LIKE CONCAT('%', #{searchValue}, '%')
+			</if>
+			</where>
+			<if test="startRowNum != null and startRowNum > -1">
+				LIMIT #{startRowNum}, #{rowPerPage};
+			</if>
 	</select>
 
 	<select id="getUserListCnt" resultType="int">
@@ -58,7 +63,16 @@
 		SELECT
 			COUNT(1)
 		FROM
-			tb_user;
+			tb_user AS u
+			INNER JOIN
+			tb_user_level AS ul
+			ON 
+			u.user_level_code = ul.user_level_code
+		<where>
+			<if test="searchKey != null and searchValue != ''">
+				${searchKey} LIKE CONCAT('%', #{searchValue}, '%');
+			</if>
+		</where>	
 	</select>
 	
 	<select id="getUserInfoById" parameterType="String" resultMap="userResultMap">

--- a/ks45team03/src/main/resources/templates/admin/main.html
+++ b/ks45team03/src/main/resources/templates/admin/main.html
@@ -25,6 +25,7 @@
 			<a th:href="@{/admin/block/adminBlockList}" style="color: blue;">관리자 회원 차단 목록</a>
 			<br>
 			<a th:href="@{/admin/profit/adminProfitList}" style="color: blue;">관리자 회원 수익 목록</a>
+			<br>
 			<a th:href="@{/admin/userManagement/userList}" style="color: blue;">회원목록</a>
 			<br>
 			<a th:href="@{/admin/board/adminInquiryList}" style="color: blue;">1 대 1 문의 게시글 목록</a>

--- a/ks45team03/src/main/resources/templates/admin/userManagement/userList.html
+++ b/ks45team03/src/main/resources/templates/admin/userManagement/userList.html
@@ -37,6 +37,16 @@
 	  </style>
 	  </head>
 	<th:block layout:fragment="customContents">
+	<form th:action="@{/admin/userManagement/userList}" method="get">
+		<select name="searchKey">
+			<option value="userId">아이디</option>
+			<option value="userLevelName">등급</option>
+			<option value="userName">이름</option>
+			<option value="userNickName">닉네임</option>
+		</select> 
+		<input type="text" name="searchValue" placeholder="검색어를 입력해주세요." />
+		<button type="submit">검색</button>
+	</form>
 	<table>
   		<thead>
 		  	<tr>


### PR DESCRIPTION
검색은 아이디, 등급이름, 이름, 닉네임으로 검색가능
검색시 페이징이 그대로 남아있어 다음페이지를 누르면 검색이 풀림
검색시 데이터의 수가 바뀌어 페이징이 가능하게 하기위해서
행갯수를 세는 메서드에 입력데이터를 넣어주어 매퍼에 where절로 수가 바뀌게 해놓음 