### PR TITLE
[220102 김대현] 페이징 모듈화, 회원 공지사항 리스트, 상세보기

### DIFF
--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminUserController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminUserController.java
@@ -37,6 +37,7 @@ public class AdminUserController {
 			 ,@RequestParam(value="searchKey", required = false) String searchKey
 			 ,@RequestParam(value="searchValue", required = false, defaultValue = "") String searchValue) {
 		
+		// 회원 목록 리스트
 		Map<String, Object> paramMap = adminUserService.userList(currentPage, searchKey, searchValue);
 		int lastPage = (int) paramMap.get("lastPage");
 		List<User> userList = (List<User>) paramMap.get("userList");

--- a/ks45team03/src/main/java/ks45team03/rentravel/dto/NoticeBoard.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/dto/NoticeBoard.java
@@ -1,0 +1,63 @@
+package ks45team03.rentravel.dto;
+
+public class NoticeBoard {
+	
+	private String noticeBoardCode;
+	private String userId;
+	private String noticeBoardTitle;
+	private String noticeBoardContent;
+	private String noticeBoardFile;
+	private String noticeBoardLikeCnt;
+	private String noticeBoardViewCnt;
+	private String noticeBoardRegTime;
+	
+	public String getNoticeBoardCode() {
+		return noticeBoardCode;
+	}
+	public void setNoticeBoardCode(String noticeBoardCode) {
+		this.noticeBoardCode = noticeBoardCode;
+	}
+	public String getUserId() {
+		return userId;
+	}
+	public void setUserId(String userId) {
+		this.userId = userId;
+	}
+	public String getNoticeBoardTitle() {
+		return noticeBoardTitle;
+	}
+	public void setNoticeBoardTitle(String noticeBoardTitle) {
+		this.noticeBoardTitle = noticeBoardTitle;
+	}
+	public String getNoticeBoardContent() {
+		return noticeBoardContent;
+	}
+	public void setNoticeBoardContent(String noticeBoardContent) {
+		this.noticeBoardContent = noticeBoardContent;
+	}
+	public String getNoticeBoardFile() {
+		return noticeBoardFile;
+	}
+	public void setNoticeBoardFile(String noticeBoardFile) {
+		this.noticeBoardFile = noticeBoardFile;
+	}
+	public String getNoticeBoardLikeCnt() {
+		return noticeBoardLikeCnt;
+	}
+	public void setNoticeBoardLikeCnt(String noticeBoardLikeCnt) {
+		this.noticeBoardLikeCnt = noticeBoardLikeCnt;
+	}
+	public String getNoticeBoardViewCnt() {
+		return noticeBoardViewCnt;
+	}
+	public void setNoticeBoardViewCnt(String noticeBoardViewCnt) {
+		this.noticeBoardViewCnt = noticeBoardViewCnt;
+	}
+	public String getNoticeBoardRegTime() {
+		return noticeBoardRegTime;
+	}
+	public void setNoticeBoardRegTime(String noticeBoardRegTime) {
+		this.noticeBoardRegTime = noticeBoardRegTime;
+	}
+	
+}

--- a/ks45team03/src/main/java/ks45team03/rentravel/dto/Pagination.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/dto/Pagination.java
@@ -1,0 +1,183 @@
+package ks45team03.rentravel.dto;
+
+public class Pagination {
+	
+	public Pagination(int listCnt, int curPage) {
+		// 현재 페이지
+		setCurPage(curPage);
+		
+		// 총 게시물 수
+		setListCnt(listCnt);
+		
+		// 총 페이지 수
+		setPageCnt(listCnt);
+		
+		// 총 블럭(range) 수
+		setRangeCnt(pageCnt);
+		
+		// 블럭(range) setting
+		rangeSetting(curPage);
+		
+		// Limit 인수 파라미터 셋팅
+		setStartIndex(curPage);
+		
+	}
+	
+	// 한 페이지당 게시글 수
+	private int pageSize = 10;
+	
+	// 한 블럭(range)당 페이지 수 [1] ... [10]
+	private int rangeSize = 10;
+	
+	// 현재 페이지 
+	private int curPage = 1;
+	
+	// 현재 블럭(range) [1]
+	private int curRange = 1;
+	
+	// 총 게시글 수 
+	private int listCnt;
+	
+	// 총 페이지 수 
+	private int pageCnt;
+	
+	// 총 블럭(range) 수
+	private int rangeCnt;
+	
+	// 시작 페이지
+	private int startPage = 1;
+	
+	// 끝 페이지
+	private int endPage = 1;
+	
+	// 시작 index
+	private int startIndex = 0;
+	
+	// 끝 index
+	private int endIndex;
+	
+	// 이전 페이지
+	private int prevPage;
+	
+	// 다음 페이지
+	private int nextPage;
+
+	public int getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(int pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public int getRangeSize() {
+		return rangeSize;
+	}
+
+	public void setRangeSize(int rangeSize) {
+		this.rangeSize = rangeSize;
+	}
+
+	public int getCurPage() {
+		return curPage;
+	}
+
+	public void setCurPage(int curPage) {
+		this.curPage = curPage;
+	}
+
+	public int getCurRange() {
+		return curRange;
+	}
+
+	public void setCurRange(int curPage) {
+		this.curRange = (int) ((curPage - 1)/rangeSize + 1);
+	}
+
+	public int getListCnt() {
+		return listCnt;
+	}
+
+	public void setListCnt(int listCnt) {
+		this.listCnt = listCnt;
+	}
+
+	public int getPageCnt() {
+		return pageCnt;
+	}
+
+	public void setPageCnt(int listCnt) {
+		this.pageCnt = (int) Math.ceil(listCnt * 1.0 / pageSize);
+	}
+
+	public int getRangeCnt() {
+		return rangeCnt;
+	}
+
+	public void setRangeCnt(int pageCnt) {
+		this.rangeCnt = (int) Math.ceil(pageCnt * 1.0 / rangeSize);
+	}
+
+	public int getStartPage() {
+		return startPage;
+	}
+
+	public void setStartPage(int startPage) {
+		this.startPage = startPage;
+	}
+
+	public int getEndPage() {
+		return endPage;
+	}
+
+	public void setEndPage(int endPage) {
+		this.endPage = endPage;
+	}
+
+	public int getStartIndex() {
+		return startIndex;
+	}
+
+	public void setStartIndex(int curPage) {
+		this.startIndex = (curPage - 1) * pageSize;
+	}
+
+	public int getEndIndex() {
+		return endIndex;
+	}
+
+	public void setEndIndex(int endIndex) {
+		this.endIndex = endIndex;
+	}
+
+	public int getPrevPage() {
+		return prevPage;
+	}
+
+	public void setPrevPage(int prevPage) {
+		this.prevPage = prevPage;
+	}
+
+	public int getNextPage() {
+		return nextPage;
+	}
+
+	public void setNextPage(int nextPage) {
+		this.nextPage = nextPage;
+	}
+	
+	public void rangeSetting(int curPage) {
+		
+		setCurRange(curPage);
+		this.startPage = (curRange - 1) * rangeSize + 1;
+		this.endPage = startPage + rangeSize - 1;
+		
+		if(endPage > pageCnt) {
+			this.endPage = pageCnt;
+		}
+		
+		this.prevPage = curPage - 1;
+		this.nextPage = curPage + 1;
+	}
+	
+}

--- a/ks45team03/src/main/java/ks45team03/rentravel/mapper/NoticeBoardMapper.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/mapper/NoticeBoardMapper.java
@@ -1,0 +1,21 @@
+package ks45team03.rentravel.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import ks45team03.rentravel.dto.NoticeBoard;
+
+@Mapper
+public interface NoticeBoardMapper {
+	
+	// 공지사항 상세보기
+	public NoticeBoard detailNoticeBoard(String noticeBoardCode);
+	
+	// 공지사항 조회
+	public List<NoticeBoard> noticeBoardList(int startIndex, int pageSize);
+	
+	// 테이블 행 갯수
+	public int noticeBoardListCnt();
+
+}

--- a/ks45team03/src/main/java/ks45team03/rentravel/user/controller/NoticeBoardController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/user/controller/NoticeBoardController.java
@@ -1,0 +1,50 @@
+package ks45team03.rentravel.user.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import ks45team03.rentravel.dto.NoticeBoard;
+import ks45team03.rentravel.dto.Pagination;
+import ks45team03.rentravel.mapper.NoticeBoardMapper;
+
+@Controller
+@RequestMapping("/board")
+public class NoticeBoardController {
+	
+	@Autowired
+	private NoticeBoardMapper noticeBoardMapper;
+	
+	@GetMapping("/noticeBoard")
+	public String noticeBoard(Model model
+							 ,@RequestParam(defaultValue="1", required=false) int curPage) {
+		
+		int listCnt = noticeBoardMapper.noticeBoardListCnt();
+		Pagination pagination = new Pagination(listCnt, curPage);
+		
+		List<NoticeBoard> noticeBoardList = noticeBoardMapper.noticeBoardList(pagination.getStartIndex(), pagination.getPageSize());
+		
+		model.addAttribute("title", "공지사항");
+		model.addAttribute("noticeBoardList", noticeBoardList);
+		model.addAttribute("pagination", pagination);
+		
+		return "user/board/noticeBoardList";
+	}
+	
+	@GetMapping("/detailNoticeBoard")
+	public String detailNoticeBoard(Model model
+								   ,@RequestParam(value = "noticeBoardCode") String noticeBoardCode) {
+		
+		NoticeBoard detailNoticeBoard = noticeBoardMapper.detailNoticeBoard(noticeBoardCode);
+		
+		model.addAttribute("title", "공지사항");
+		model.addAttribute("detailNoticeBoard", detailNoticeBoard);
+		
+		return "user/board/detailNoticeBoard";
+	}
+}

--- a/ks45team03/src/main/resources/mapper/noticeBoadMapper.xml
+++ b/ks45team03/src/main/resources/mapper/noticeBoadMapper.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="ks45team03.rentravel.mapper.NoticeBoardMapper">
+	<resultMap type="NoticeBoard" id="noticeBoardResultMap">
+		<id property="noticeBoardCode" column="notice_board_code" />
+		<result property="userId" column="user_id" />
+		<result property="noticeBoardTitle" column="notice_board_title" />
+		<result property="noticeBoardContent" column="notice_board_content" />
+		<result property="noticeBoardFile" column="notice_board_file" />
+		<result property="noticeBoardLikeCnt" column="notice_board_like_cnt" />
+		<result property="noticeBoardViewCnt" column="notice_board_view_cnt" />
+		<result property="noticeBoardRegTime" column="notice_board_reg_time" />
+	</resultMap>
+	
+	<select id="detailNoticeBoard" resultMap="noticeBoardResultMap">
+		SELECT
+			 nb.user_id
+			,nb.notice_board_title
+			,nb.notice_board_content
+			,nb.notice_board_file
+			,nb.notice_board_like_cnt
+			,nb.notice_board_view_cnt
+			,nb.notice_board_reg_time
+		FROM
+			tb_notice_board AS nb
+		WHERE
+			nb.notice_board_code = #{noticeBoardCode};
+	</select>
+	
+	<select id="noticeBoardList" resultMap="noticeBoardResultMap">
+		SELECT
+			 nb.notice_board_code
+			,nb.user_id
+			,nb.notice_board_title
+			,nb.notice_board_content
+			,nb.notice_board_file
+			,nb.notice_board_like_cnt
+			,nb.notice_board_view_cnt
+			,nb.notice_board_reg_time
+		FROM
+			tb_notice_board AS nb
+		<if test="startIndex != null and startIndex > -1">
+			LIMIT #{startIndex}, #{pageSize};
+		</if>
+	</select>
+	
+	<select id="noticeBoardListCnt" resultType="int">
+		SELECT
+			COUNT(1)
+		FROM
+			tb_notice_board;
+	</select>
+</mapper>

--- a/ks45team03/src/main/resources/templates/user/board/detailNoticeBoard.html
+++ b/ks45team03/src/main/resources/templates/user/board/detailNoticeBoard.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	  layout:decorate="~{user/layout/default}">
+	  
+	  <th:block layout:fragment="customContents">
+		<!-- LIGHT SECTION -->
+		<section class="lightSection clearfix pageHeader">
+		  <div class="container">
+		    <div class="row">
+		      <div class="col-md-6">
+		        <div class="page-title">
+		          <h2>Notice Board Detail</h2>
+		        </div>
+		      </div>
+		      <div class="col-md-6">
+		        <ol class="breadcrumb float-right">
+		          <li>
+		            <a th:href="@{/}">Home</a>
+		          </li>
+		          <li>
+		          	<a th:href="@{/board/noticeBoard}">Notice Board List</a>
+		          </li>
+		          <li class="active">Notice Board Detail</li>
+		        </ol>
+		      </div>
+		    </div>
+		  </div>
+		</section>
+	  	<section class="mainContent clearfix blogPage singleBlog">
+		  <div class="container">
+		    <div class="row">
+		      <div class="col-md-12">
+		        <div class="thumbnail">
+		          <div class="caption">
+		            <div class="row">
+		              <div class="col-md-3 order-md-12">
+		                <h5>Infomation</h5>
+		                <ul class="list-unstyled">
+		                  <li>
+		                    <i class="fa fa-user" aria-hidden="true"></i><span th:text="${detailNoticeBoard.userId}"></span>
+		                  </li>
+		                  <li>
+		                    <i class="fa fa-calendar" aria-hidden="true"></i><span th:text="${detailNoticeBoard.noticeBoardRegTime}"></span>
+	                      </li>
+	                      <li>
+	                      	<i class="bi bi-hand-thumbs-up-fill"></i><span th:text="${detailNoticeBoard.noticeBoardLikeCnt}"></span>
+	                      </li>
+	                      <li>
+	                      	<i class="bi bi-eye-fill"></i><span th:text="${detailNoticeBoard.noticeBoardViewCnt}"></span>
+	                      	</li>
+		                </ul>
+		                
+		                <h5>Share</h5>
+		                <ul class="list-inline">
+		                  <li>
+		                    <a href="#">
+		                      <i class="fa fa-facebook" aria-hidden="true"></i>
+		                    </a>
+		                  </li>
+		                  <li>
+		                    <a href="#">
+		                      <i class="fa fa-twitter" aria-hidden="true"></i>
+		                    </a>
+		                  </li>
+		                  <li>
+		                    <a href="#">
+		                      <i class="fa fa-dribbble" aria-hidden="true"></i>
+		                    </a>
+		                  </li>
+		                  <li>
+		                    <a href="#">
+		                      <i class="fa fa-tumblr" aria-hidden="true"></i>
+		                    </a>
+		                  </li>
+		                </ul>
+		                <ul class="list-unstyled">
+		                </ul>
+		              </div>
+		              <div class="col-md-9 order-md-1">
+		                <h3 th:text="${detailNoticeBoard.noticeBoardTitle}"></h3>
+		                <img src="/user/assets/img/blog/blog-01.jpg" alt="blog-image">
+		                <p th:text="${detailNoticeBoard.noticeBoardContent}"></p>
+		              </div>
+		            </div>
+		          </div>
+		          <ul class="pager">
+		            <li class="previous">
+		              <a href="#">previous</a>
+		            </li>
+		            <li class="next float-right">
+		              <a href="#">next</a>
+		            </li>
+		          </ul>
+		        </div>
+		      </div>
+		    </div>
+		  </div>
+		</section>
+	  </th:block>
+</html>

--- a/ks45team03/src/main/resources/templates/user/board/noticeBoardList.html
+++ b/ks45team03/src/main/resources/templates/user/board/noticeBoardList.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{user/layout/default}">
+<th:block layout:fragment="customContents">
+	<!-- LIGHT SECTION -->
+	<section class="lightSection clearfix pageHeader">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-6">
+					<div class="page-title">
+						<h2>Notice Board List</h2>
+					</div>
+				</div>
+				<div class="col-md-6">
+					<ol class="breadcrumb float-right">
+						<li><a th:href="@{/}">Home</a></li>
+						<li class="active">Notice Board List</li>
+					</ol>
+				</div>
+			</div>
+		</div>
+	</section>
+	<section class="mainContent clearfix blogPage">
+		<div class="container">
+			<div class="row">
+				<div class="col-lg-9 col-sm-12 order-lg-12">
+					<!-- 게시판 시작 -->
+					<div class="row">
+						<!-- 게시판 행 시작 -->
+						<div class="col-sm-12" th:unless="${#lists.isEmpty(noticeBoardList)}" th:each="nb : ${noticeBoardList}">
+							<div class="thumbnail">
+								<div class="caption">
+									<div class="row">
+										<div class="col-md-3 order-md-12">
+											<h5>Board Info</h5>
+											<ul class="list-unstyled">
+												<li>
+													<a href="#"><i class="fa fa-user" aria-hidden="true"></i><span th:text="${nb.userId}"></span></a>
+												</li>
+												<li>
+													<i class="bi bi-hand-thumbs-up-fill"></i><span th:text="${nb.noticeBoardLikeCnt} + ' likes'"></span>
+												</li>
+												<li>
+													<i class="bi bi-eye-fill"></i><span th:text="${nb.noticeBoardViewCnt} + ' views'"></span>
+												</li>
+											</ul>
+										</div>
+										<div class="col-md-9 order-md-1">
+											<h3>
+												<a href="blog-single-left-sidebar.html" th:href="@{/board/detailNoticeBoard(noticeBoardCode=${nb.noticeBoardCode})}" th:text="${nb.noticeBoardTitle}"></a>
+											</h3>
+											<ul class="list-unstyled">
+												<li><i class="fa fa-calendar" aria-hidden="true"></i><span th:text="${nb.noticeBoardRegTime}"></span></li>
+											</ul>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="col-sm-12" th:if="${#lists.isEmpty(noticeBoardList)}" th:each="nb : ${noticeBoardList}">
+							<div class="thumbnail">
+								<div class="caption">
+									<div class="row">
+										<div class="col-md-9 order-md-1">
+											<h3>
+												<a href="blog-single-left-sidebar.html">게시글이 존재하지 않습니다.</a>
+											</h3>
+											<p>게시글을 입력해주세요.</p>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-sm-12">
+							<div class="text-left">
+								<ul class="pagination">
+									<li th:if="${pagination.curRange != 1}">
+										<a th:href="@{/board/noticeBoard}" aria-label="First"><span aria-hidden="true"><<</span></a>
+									</li>
+									<li th:if="${pagination.curPage != 1}">
+										<a th:href="@{/board/noticeBoard(curPage=${pagination.prevPage})}" aria-label="Prev"> <span aria-hidden="true">&#60;</span></a>
+									</li>
+									
+									<th:block th:each="pageNum : ${#numbers.sequence(pagination.startPage, pagination.endPage)}">
+										<li class="active" th:if="${pageNum == pagination.curPage}">
+											<a th:text="${pageNum}"></a>
+										</li>
+										<li th:unless="${pageNum == pagination.curPage}">
+											<a th:href="@{/board/noticeBoard(curPage=${pageNum})}" th:text="${pageNum}"></a>
+										</li>
+									</th:block>
+
+									<li th:if="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}">
+										<a th:href="@{/board/noticeBoard(curPage=${pagination.nextPage})}" aria-label="Next"> <span aria-hidden="true">&#62;</span></a>
+									</li>
+									<li th:if="${pagination.curRange != pagination.rangeCnt && pagination.rangeCnt > 0}">
+										<a th:href="@{/board/noticeBoard(curPage=${pagination.pageCnt})}" aria-label="Last"> <span aria-hidden="true">>></span></a>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+</th:block>
+</html>

--- a/ks45team03/src/main/resources/templates/user/main.html
+++ b/ks45team03/src/main/resources/templates/user/main.html
@@ -44,9 +44,9 @@
 					  	<h3><a th:href="@{/board/inquiryList}" style="color:blue;">1 대 1 문의 게시판 리스트</a></h3>
 					  	<h3><a th:href="@{/myPage/myInfo}" style="color:blue;">마이페이지</a></h3>
 					  	<h3><a th:href="@{/addUser}" style="color:blue;">회원가입</a></h3>
-					  	<h3><a th:href="@{/login}" style="color:blue;">로그인</a></h3>
 					  	<h3><a th:href="@{/goods/addGoods}" style="color:blue;">상품추가</a></h3>
 					  	<h3><a th:href="@{/chat/chatRoomList}" style="color:blue;">내 채팅방 목록</a></h3>
+					  	<h3><a th:href="@{/board/noticeBoard}" style="color:blue;">공지사항</a></h3>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
페이징 모듈화, 회원 공지사항 리스트, 상세보기
[1] ... [10]

1일때 이전 없음
마지막번호일때 다음 없음
[11]로 넘어가야 첫번째 페이지로 갈 수있는 버튼이 생김
마찬가지로 [10]이후의 페이지가 있어야 마지막페이지로 갈 수 있는 버튼이 생김

페이징을 각 서비스마다 작성하느건 불필요하다 생각해서 모듈화함

그리고 의존성주입은 @autowired라는 어노테이션으로 대체하여 코드를 줄일 수 있음
단, 두개 이상은 또 다른 방법이 추가됨.

모듈화된 페이징을 바탕으로 공지사항 게시판 작성
서비스단을 거치지 않고 바로 매퍼로 보내 불필요한 작업을 제거

추후 조회수가 작동하도록 수정예정