### PR TITLE
[230116 김대현]공지사항, FAQ 수정 및 관리자 페이지 관리자 아닐때 접근제한, 관리자 메인페이지 세션추가

### DIFF
--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminFaqController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminFaqController.java
@@ -1,6 +1,7 @@
 package ks45team03.rentravel.admin.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,12 +10,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import ks45team03.rentravel.admin.service.AdminFAQService;
 import ks45team03.rentravel.dto.FAQ;
 import ks45team03.rentravel.dto.FAQCategory;
 import ks45team03.rentravel.dto.LoginInfo;
 import ks45team03.rentravel.dto.Pagination;
+import ks45team03.rentravel.dto.Search;
 import ks45team03.rentravel.mapper.AdminFAQMapper;
 import lombok.AllArgsConstructor;
 
@@ -28,18 +31,21 @@ public class AdminFaqController {
 	
 	@GetMapping("/adminFAQ")
 	public String adminFAQ(@RequestParam(defaultValue="1", required=false) int curPage
-						  ,@RequestParam(value="searchKey", required = false) String searchKey
+						  ,@RequestParam(value="searchKey", required = false, defaultValue = "") String searchKey
 						  ,@RequestParam(value="searchValue", required = false, defaultValue = "") String searchValue
 						  ,Model model) {
 		
+		
 		int listCnt = adminFAQMapper.faqListCnt(searchKey, searchValue);
 		Pagination pagination = new Pagination(listCnt, curPage);
+		Search search = new Search(searchKey, searchValue);
 		
 		List<FAQ> adminFAQList = adminFAQService.adminFAQList(pagination.getStartIndex(), pagination.getPageSize(), searchKey, searchValue);
 
 		model.addAttribute("title", "FAQ");
 		model.addAttribute("adminFAQList", adminFAQList);
 		model.addAttribute("pagination", pagination);
+		model.addAttribute("search", search);
 		
 		return "admin/board/adminFAQList";
 	}

--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminMainController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminMainController.java
@@ -4,7 +4,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import ks45team03.rentravel.dto.LoginInfo;
 
@@ -13,10 +15,24 @@ import ks45team03.rentravel.dto.LoginInfo;
 public class AdminMainController {
 	
 	@GetMapping("/admin")
-	public String adminMain(Model model) {
+	public String adminMain(Model model, HttpSession session) {
 		
-		model.addAttribute("title", "관리자 메인화면");
+		LoginInfo loginUser = (LoginInfo) session.getAttribute("S_USER_INFO");
+		String redirectURI = "admin/main";
 		
-		return "admin/main";
+		if(loginUser == null) {
+		
+			redirectURI = "redirect:/login";	
+			
+		}else if(loginUser.getLoginLevelName().equals("관리자")){
+			
+			model.addAttribute("title", "관리자 메인화면");
+			
+		}else {
+			
+			redirectURI = "redirect:/";	
+		}
+		
+		return redirectURI;
 	}
 }

--- a/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminNoticeBoardController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/admin/controller/AdminNoticeBoardController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import jakarta.servlet.http.HttpSession;
 import ks45team03.rentravel.dto.LoginInfo;
 import ks45team03.rentravel.dto.NoticeBoard;
+import ks45team03.rentravel.dto.Pagination;
+import ks45team03.rentravel.dto.Search;
 import ks45team03.rentravel.mapper.AdminNoticeBoardMapper;
 
 @Controller
@@ -23,12 +25,22 @@ public class AdminNoticeBoardController {
 	private AdminNoticeBoardMapper adminNoticeBoardMapper;
 	
 	@GetMapping("/adminNoticeBoard")
-	public String noticeBoard(Model model) {
+	public String noticeBoard(@RequestParam(defaultValue="1", required=false) int curPage
+							 ,@RequestParam(value="searchKey", required = false, defaultValue = "") String searchKey
+							 ,@RequestParam(value="searchValue", required = false, defaultValue = "") String searchValue
+							 ,Model model) {
 		
-		List<NoticeBoard> adminNoticeBoardList = adminNoticeBoardMapper.adminNoticeBoardList();
+		
+		int listCnt = adminNoticeBoardMapper.noticeBoardListCnt(searchKey, searchValue);
+		Pagination pagination = new Pagination(listCnt, curPage);
+		Search search = new Search(searchKey, searchValue);
+		
+		List<NoticeBoard> adminNoticeBoardList = adminNoticeBoardMapper.adminNoticeBoardList(pagination.getStartIndex(), pagination.getPageSize(), searchKey, searchValue);
 		
 		model.addAttribute("title", "공지사항");
 		model.addAttribute("adminNoticeBoardList", adminNoticeBoardList);
+		model.addAttribute("pagination", pagination);
+		model.addAttribute("search", search);
 		
 		return "admin/board/adminNoticeBoardList";
 	}

--- a/ks45team03/src/main/java/ks45team03/rentravel/dto/NoticeBoard.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/dto/NoticeBoard.java
@@ -12,10 +12,9 @@ public class NoticeBoard {
 	private String noticeBoardCode;
 	private int num;
 	private String userId;
+	private String userNickName;
 	private String noticeBoardTitle;
 	private String noticeBoardContent;
 	private String noticeBoardFile;
-	private String noticeBoardLikeCnt;
-	private String noticeBoardViewCnt;
 	private String noticeBoardRegTime;
 }

--- a/ks45team03/src/main/java/ks45team03/rentravel/dto/Search.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/dto/Search.java
@@ -8,6 +8,12 @@ import lombok.ToString;
 @Setter
 @ToString
 public class Search {
+	
+	 public Search(String searchKey, String searchValue) { 
+		 this.searchKey = searchKey; 
+		 this.searchValue = searchValue; 
+		 }
+	 
 	private String searchKey;
 	private String searchValue;
 }

--- a/ks45team03/src/main/java/ks45team03/rentravel/mapper/AdminNoticeBoardMapper.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/mapper/AdminNoticeBoardMapper.java
@@ -8,9 +8,11 @@ import ks45team03.rentravel.dto.NoticeBoard;
 
 @Mapper
 public interface AdminNoticeBoardMapper {
+	
+	public int noticeBoardListCnt(String searchKey, String searchValue);
 
 	// 공지사항 리스트
-	public List<NoticeBoard> adminNoticeBoardList();
+	public List<NoticeBoard> adminNoticeBoardList(int startIndex, int pageSize, String searchKey, String searchValue);
 	
 	// 공지사항 상세보기
 	public NoticeBoard adminDetailNoticeBoard(String noticeBoardCode);

--- a/ks45team03/src/main/java/ks45team03/rentravel/user/controller/GoodsController.java
+++ b/ks45team03/src/main/java/ks45team03/rentravel/user/controller/GoodsController.java
@@ -49,9 +49,7 @@ public class GoodsController {
 		List<Goods> goodsCategoryAndCount = goodsService.getGoodsCategoryAndCount();
 		LoginInfo loginUser = (LoginInfo) session.getAttribute("S_USER_INFO");
 		
-		Search searchResult = new Search();
-		searchResult.setSearchKey(searchKey);
-		searchResult.setSearchValue(searchValue);
+		Search searchResult = new Search(searchKey, searchValue);
 		
 		if(loginUser == null) {
 			

--- a/ks45team03/src/main/resources/mapper/adminNoticeBoardMapper.xml
+++ b/ks45team03/src/main/resources/mapper/adminNoticeBoardMapper.xml
@@ -6,11 +6,10 @@
 	<resultMap type="NoticeBoard" id="noticeBoardResultMap">
 		<id property="noticeBoardCode" column="notice_board_code" />
 		<result property="userId" column="user_id" />
+		<result property="userNickName" column="user_nickname" />
 		<result property="noticeBoardTitle" column="notice_board_title" />
 		<result property="noticeBoardContent" column="notice_board_content" />
 		<result property="noticeBoardFile" column="notice_board_file" />
-		<result property="noticeBoardLikeCnt" column="notice_board_like_cnt" />
-		<result property="noticeBoardViewCnt" column="notice_board_view_cnt" />
 		<result property="noticeBoardRegTime" column="notice_board_reg_time" />
 	</resultMap>
 	
@@ -19,29 +18,61 @@
 			@rownum:=@rownum+1 AS num
 			,nb.notice_board_code
 			,nb.user_id
+			,u.user_nickname
 			,nb.notice_board_title
 			,nb.notice_board_content
 			,nb.notice_board_file
-			,nb.notice_board_like_cnt
-			,nb.notice_board_view_cnt
 			,nb.notice_board_reg_time
 		FROM
-			tb_notice_board AS nb, (SELECT @rownum:=0) AS TMP
-		ORDER BY 
-			num DESC;
+			tb_notice_board AS nb
+			INNER JOIN
+			tb_user AS u
+			ON
+			nb.user_id = u.user_id
+			, (SELECT @rownum:=0) AS TMP
+		<where>
+			<if test="searchKey != null and searchKey != ''">		
+				${searchKey} LIKE CONCAT('%', #{searchValue}, '%')
+			</if>
+		</where>
+			ORDER BY 
+				num DESC
+		<if test="startIndex != null and startIndex > -1">
+			LIMIT #{startIndex}, #{pageSize};
+		</if>
+	</select>
+	
+	<select id="noticeBoardListCnt" resultType="int">
+		SELECT
+			COUNT(1)
+		FROM
+			tb_notice_board AS nb
+			INNER JOIN
+			tb_user AS u
+			ON
+			nb.user_id = u.user_id	
+		<where>
+			<if test="searchKey != null and searchKey != ''">		
+				${searchKey} LIKE CONCAT('%', #{searchValue}, '%');
+			</if>	
+		</where>
 	</select>
 	
 	<select id="adminDetailNoticeBoard" parameterType="String" resultMap="noticeBoardResultMap">
 	   SELECT
 			 nb.user_id
+			,u.user_nickname
 			,nb.notice_board_code
 			,nb.notice_board_title
 			,nb.notice_board_content
 			,nb.notice_board_file
-			,nb.notice_board_view_cnt
 			,nb.notice_board_reg_time
 		FROM
 			tb_notice_board AS nb
+			INNER JOIN
+			tb_user AS u
+			ON
+			nb.user_id = u.user_id	
 		WHERE
 			nb.notice_board_code = #{noticeBoardCode};
 	</select>

--- a/ks45team03/src/main/resources/templates/admin/board/adminDetailNoticeBoard.html
+++ b/ks45team03/src/main/resources/templates/admin/board/adminDetailNoticeBoard.html
@@ -25,10 +25,9 @@
 								<div class="col-md-12 col-sm-12 ">
 									<div th:text="${detailNoticeBoard.noticeBoardTitle}"
 										style="font-size: 25px"></div>
-									<div th:text="${detailNoticeBoard.userId}"></div>
+									<div th:text="${detailNoticeBoard.userNickName}"></div>
 									<div>
 										<span th:text="${detailNoticeBoard.noticeBoardRegTime}" style="margin-right: 10px"></span>
-										<span th:text="| 조회 ${detailNoticeBoard.noticeBoardViewCnt}|"></span>
 									</div>
 								</div>
 							</div>

--- a/ks45team03/src/main/resources/templates/admin/board/adminFAQList.html
+++ b/ks45team03/src/main/resources/templates/admin/board/adminFAQList.html
@@ -29,7 +29,7 @@
                  <div class="clearfix"></div>
                </div>
                <div id="searchAndAdd">
-	               <form th:action="@{/admin/board/adminFAQ}" method="get" class="input-group col-md-4">
+	               <form id="searchForm" th:action="@{/admin/board/adminFAQ}" method="get" class="input-group col-md-4">
 					<select name="searchKey" class="form-control">
 						<option value="ca.faq_board_category_name">카테고리</option>
 						<option value="u.user_nickname">작성자</option>
@@ -37,7 +37,7 @@
 						<option value="faq.faq_board_frequently">자주 묻는 질문</option>
 					</select>
 					<input class="form-control" type="text" name="searchValue" placeholder="검색어를 입력해주세요."/>
-					<button class="btn btn-dark" type="submit">검색</button>
+					<button id="searchFormBtn" class="btn btn-dark" type="submit">검색</button>
 					</form>
 					<a class="btn btn-dark form-control col-md-1" th:href="@{/admin/board/adminAddFAQ}">작성</a>
                </div>
@@ -46,21 +46,21 @@
                       <table class="table table-striped jambo_table bulk_action">
                         <thead>
                           <tr class="headings">
-			                <th class="column-title"></th>
+			                <th class="column-title">구분</th>
 			                <th class="column-title">제목</th>
 			                <th class="column-title">작성자</th>
 			                <th class="column-title">작성일</th>
-			                <th class="column-title">자주묻는질문</th>
+			                <th class="column-title">옵션</th>
 			              </tr>
 	                     </thead>
 			       
                         <tbody>
 			            <tr th:unless="${#lists.isEmpty(adminFAQList)}" th:each="faq : ${adminFAQList}">
-			                <td th:text="|[${faq.faqBoardCategoryName}]|"></td>
-			                <td style="overflow: hidden; text-overflow: ellipsis;"><a th:text="${faq.faqBoardTitle}" th:href="@{/admin/board/adminDetailFAQ(faqBoardCode=${faq.faqBoardCode})}"></a></td>
-			                <td th:text="${faq.userNickName}"></td>
-			                <td th:text="${faq.faqBoardRegTime}"></td>		
-			                <td th:text="${faq.faqBoardFrequently}"></td>		
+			                <td style="width: 10%" th:text="|[${faq.faqBoardCategoryName}]|"></td>
+			                <td style="overflow: hidden; text-overflow: ellipsis; width: 65%"><a th:text="${faq.faqBoardTitle}" th:href="@{/admin/board/adminDetailFAQ(faqBoardCode=${faq.faqBoardCode})}"></a></td>
+			                <td style="width: 10%" th:text="${faq.userNickName}"></td>
+			                <td style="width: 10%" th:text="${faq.faqBoardRegTime}"></td>		
+			                <td style="width: 5%" th:text="${faq.faqBoardFrequently}"></td>		
 			              </tr>
 			              <tr th:if="${#lists.isEmpty(adminFAQList)}">
 			              	<td colspan="5">등록된 작성글이 없습니다.</td>
@@ -73,26 +73,26 @@
 							<div class="text-left">
 								<ul class="pagination">
 									<li th:if="${pagination.curPage != 1}" class="page-item">
-										<a th:href="@{/admin/board/adminFAQ(curPage=${pagination.prevPage})}" aria-label="Prev" class="page-link"> <span aria-hidden="true">&#60;</span></a>
+										<a th:href="@{/admin/board/adminFAQ(searchKey=${search.searchKey}, searchValue=${search.searchValue}, curPage=${pagination.prevPage})}" aria-label="Prev" class="page-link"> <span aria-hidden="true">&#60;</span></a>
 									</li>
-									<li th:unless="${pagination.curPage != 1}" class="page-item">
-										<span aria-label="Prev" class="page-link"> <span aria-hidden="true">&#60;</span></span>
+									<li th:unless="${pagination.curPage != 1}" class="page-item disabled">
+										<span aria-label="Prev" class="page-link" tabindex="-1" aria-disabled="true"> <span aria-hidden="true">&#60;</span></span>
 									</li>
 									
 									<th:block th:each="pageNum : ${#numbers.sequence(pagination.startPage, pagination.endPage)}">
-										<li class="page-item" th:if="${pageNum == pagination.curPage}">
+											<li class="page-item active" aria-current="page" th:if="${pageNum == pagination.curPage}">
 											<span th:text="${pageNum}" class="page-link"></span>
 										</li>
 										<li th:unless="${pageNum == pagination.curPage} or ${pagination.listCnt == 0}" class="page-item">
-											<a th:href="@{/admin/board/adminFAQ(curPage=${pageNum})}" th:text="${pageNum}" class="page-link"></a>
+											<a th:href="@{/admin/board/adminFAQ(searchKey=${search.searchKey}, searchValue=${search.searchValue}, curPage=${pageNum})}" th:text="${pageNum}" class="page-link"></a>
 										</li>
 									</th:block>
 
 									<li th:if="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}" class="page-item">
-										<a th:href="@{/admin/board/adminFAQ(curPage=${pagination.nextPage})}" aria-label="Next" class="page-link"> <span aria-hidden="true">&#62;</span></a>
+										<a th:href="@{/admin/board/adminFAQ(searchKey=${search.searchKey}, searchValue=${search.searchValue}, curPage=${pagination.nextPage})}" aria-label="Next" class="page-link"> <span aria-hidden="true">&#62;</span></a>
 									</li>
-									<li th:unless="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}">
-										<span aria-label="Next" class="page-link"><span aria-hidden="true">&#62;</span></span>
+									<li th:unless="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}" class="page-item disabled">
+										<span aria-label="Next" class="page-link" tabindex="-1" aria-disabled="true"><span aria-hidden="true">&#62;</span></span>
 									</li>
 								</ul>
 							</div>
@@ -107,4 +107,17 @@
         </div>
       <!-- /page content -->
 	</th:block>
+	
+ 	 <th:block layout:fragment="customScript">
+       	<script th:inline="javascript">
+			$('#searchFormBtn').click(function(e){
+				$('#searchForm').find("input[name='']").val('1');
+				e.preventDefault();
+				
+				$('#searchForm').submit();
+				
+			});
+	    </script>
+    </th:block> 
+	
 </html>

--- a/ks45team03/src/main/resources/templates/admin/board/adminNoticeBoardList.html
+++ b/ks45team03/src/main/resources/templates/admin/board/adminNoticeBoardList.html
@@ -2,59 +2,104 @@
 <html xmlns:th="http://www.thymeleaf.org"
 	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 	layout:decorate="~{admin/layout/default}">
-	
+	<head>
+		<style type="text/css">
+			table{
+				width: 100%;
+			}
+			tr, td {
+				text-align:center;
+			}
+			#pg {
+				display: flex;
+				justify-content: center;
+			}
+			#searchAndAdd {
+				display: flex;
+				justify-content: space-between;
+			}
+		</style>
+	</head>
 	<th:block layout:fragment="customContents">
-  	  <!-- page content -->
-      <div class="right_col" role="main">
-
-          <div class="clearfix"></div>
-
-          <div class="row">
-            <div class="col-md-12 col-sm-12 ">
-              <div class="x_panel">
-                <div class="x_title">
-                  <h2>공지사항 <small>NoticeBoard</small></h2>
-                  <div class="clearfix"></div>
-                </div>
-                <div class="x_content">
-                  <div class="row">
-                    <div class="col-sm-12">
-                      <div class="card-box table-responsive">
-                        <p class="text-muted font-13 m-b-30">
-                          공지사항 게시판입니다.
-                        <a class="btn btn-light" style="float: right" th:href="@{/admin/board/adminAddNoticeBoard}">작성</a>
-                        </p>
-                        <table id="datatable" class="table table-striped table-bordered" style="width:100%; white-space: nowrap;">
-                          <thead>
-                            <tr>
-						  		<th>번호</th>
-						  		<th>제목</th>
-						  		<th>작성자</th>
-						  		<th>작성일</th>
-						  		<th>조회</th>
-                            </tr>
-                          </thead>
-                          <tbody>
+      <div id="rightcolumn" class="right_col" role="main">
+		<div class="col-md-12 col-sm-12">
+			<div class="x_panel">
+               <div class="x_title">
+                 <h2>공지사항</h2>
+                 <div class="clearfix"></div>
+               </div>
+               <div id="searchAndAdd">
+	               <form th:action="@{/admin/board/adminNoticeBoard}" method="get" class="input-group col-md-4">
+					<select name="searchKey" class="form-control">
+						<option value="nb.notice_board_content">제목</option>
+						<option value="u.user_nickname">작성자</option>
+						<option value="nb.notice_board_reg_time">작성일</option>
+					</select>
+					<input class="form-control" type="text" name="searchValue" placeholder="검색어를 입력해주세요."/>
+					<button class="btn btn-dark" type="submit">검색</button>
+					</form>
+					<a class="btn btn-dark form-control col-md-1" th:href="@{/admin/board/adminAddNoticeBoard}">작성</a>
+               </div>
+           	  <div class="x_content">
+                <div class="table-responsive">
+                      <table class="table table-striped jambo_table bulk_action">
+                        <thead>
+                          <tr class="headings">
+			                <th class="column-title">번호</th>
+			                <th class="column-title">제목</th>
+			                <th class="column-title">작성자</th>
+			                <th class="column-title">작성일</th>
+			              </tr>
+	                     </thead>
+			       
+                        <tbody>
                             <tr th:if="${not #lists.isEmpty(adminNoticeBoardList)}" th:each="anb : ${adminNoticeBoardList}">
-					  			<td th:text="${anb.num}"></td>
-					  			<td style="overflow: hidden; text-overflow: ellipsis;"><a th:text="${anb.noticeBoardTitle}" th:href="@{/admin/board/adminDetailNoticeBoard(noticeBoardCode=${anb.noticeBoardCode})}"></a></td>
-					  			<td th:text="${anb.userId}"></td>
-					  			<td th:text="${anb.noticeBoardRegTime}"></td>
-					  			<td th:text="${anb.noticeBoardViewCnt}"></td>
+					  			<td style="width: 5%" th:text="${anb.num}"></td>
+					  			<td style="overflow: hidden; text-overflow: ellipsis; width:70%"><a th:text="${anb.noticeBoardTitle}" th:href="@{/admin/board/adminDetailNoticeBoard(noticeBoardCode=${anb.noticeBoardCode})}"></a></td>
+					  			<td style="width: 10%" th:text="${anb.userNickName}"></td>
+					  			<td style="width: 15%" th:text="${anb.noticeBoardRegTime}"></td>
                             <tr th:unless="${not #lists.isEmpty(adminNoticeBoardList)}">
-	  							<td>작성된 글이 없습니다.</td>
+	  							<td colspan="4">작성된 글이 없습니다.</td>
 	  						</tr>
                           </tbody>
-                        </table>
-                      </div>
+                      </table>
+			       <div class="row">
+						<div class="col-sm-12"  id="pg">
+							<div class="text-left">
+								<ul class="pagination">
+									<li th:if="${pagination.curPage != 1}" class="page-item">
+										<a th:href="@{/admin/board/adminNoticeBoard(searchKey=${search.searchKey}, searchValue=${search.searchValue},curPage=${pagination.prevPage})}" aria-label="Prev" class="page-link"> <span aria-hidden="true">&#60;</span></a>
+									</li>
+									<li th:unless="${pagination.curPage != 1}" class="page-item disabled">
+										<span aria-label="Prev" class="page-link" tabindex="-1" aria-disabled="true"> <span aria-hidden="true">&#60;</span></span>
+									</li>
+									
+									<th:block th:each="pageNum : ${#numbers.sequence(pagination.startPage, pagination.endPage)}">
+										<li class="page-item active" aria-current="page" th:if="${pageNum == pagination.curPage}">
+											<span th:text="${pageNum}" class="page-link"></span>
+										</li>
+										<li th:unless="${pageNum == pagination.curPage} or ${pagination.listCnt == 0}" class="page-item">
+											<a th:href="@{/admin/board/adminNoticeBoard(searchKey=${search.searchKey}, searchValue=${search.searchValue}, curPage=${pageNum})}" th:text="${pageNum}" class="page-link"></a>
+										</li>
+									</th:block>
+
+									<li th:if="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}" class="page-item">
+										<a th:href="@{/admin/board/adminNoticeBoard(searchKey=${search.searchKey}, searchValue=${search.searchValue},curPage=${pagination.nextPage})}" aria-label="Next" class="page-link"> <span aria-hidden="true">&#62;</span></a>
+									</li>
+									<li th:unless="${pagination.curPage != pagination.pageCnt && pagination.pageCnt > 0}" class="page-item disabled">
+										<span aria-label="Next" class="page-link" tabindex="-1" aria-disabled="true"><span aria-hidden="true">&#62;</span></span>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+			         
                     </div>
+							                 
                   </div>
-                </div>
-              </div>
-            </div>
+          </div>
           </div>
         </div>
-      </div>
       <!-- /page content -->
-  	</th:block>
+	</th:block>
 </html>

--- a/ks45team03/src/main/resources/templates/admin/fragments/naviFragment.html
+++ b/ks45team03/src/main/resources/templates/admin/fragments/naviFragment.html
@@ -8,19 +8,10 @@
              </div>
              <nav class="nav navbar-nav">
              <ul class=" navbar-right">
-               <li class="nav-item dropdown open" style="padding-left: 15px;">
-                 <a href="javascript:;" class="user-profile dropdown-toggle" aria-haspopup="true" id="navbarDropdown" data-toggle="dropdown" aria-expanded="false">
-                   <img th:src="@{/admin/images/img.jpg}" alt="" />관리자님
+               <li class="nav-item" style="padding-left: 15px;">
+                 <a href="javascript:;" class="user-profile" aria-haspopup="true">
+                   <img th:src="@{/admin/images/img.jpg}" alt="" /><span th:text="|${session.S_USER_INFO.loginNickName} 관리자님|"></span>
 				 </a>
-                 <div class="dropdown-menu dropdown-usermenu pull-right" aria-labelledby="navbarDropdown">
-                   <a class="dropdown-item"  href="javascript:;"> Profile</a>
-                     <a class="dropdown-item"  href="javascript:;">
-                       <span class="badge bg-red pull-right">50%</span>
-                       <span>Settings</span>
-                     </a>
-                 <a class="dropdown-item"  href="javascript:;">Help</a>
-                   <a class="dropdown-item"  href="login.html"><i class="fa fa-sign-out pull-right"></i> Log Out</a>
-                 </div>
                </li>
 			</ul>
            </nav>

--- a/ks45team03/src/main/resources/templates/user/fragments/naviFragment.html
+++ b/ks45team03/src/main/resources/templates/user/fragments/naviFragment.html
@@ -125,8 +125,8 @@
                   <a href="javascript:void(0)" class="dropdown-toggle nav-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community</a>
                   <ul class="dropdown-menu dropdown-menu-left">
                     <li class=""><a th:href="@{/infoboard/infoBoardList}">Info Board</a></li>
-                    <li class=""><a href="">#Notice</a></li>
-                    <li class=""><a th:href="@{/board/inquiryList}">FAQ</a></li>
+                    <li class=""><a th:href="@{/board/noticeBoard}">#Notice</a></li>
+                    <li class=""><a th:href="@{/board/FAQList}">FAQ</a></li>
                     <li class=""><a th:href="@{/board/inquiryList}">Q&A</a></li>
                   </ul>
                 </li>

--- a/ks45team03/src/main/resources/templates/user/main.html
+++ b/ks45team03/src/main/resources/templates/user/main.html
@@ -33,7 +33,6 @@
 						
 					  	<h1>메인화면</h1>
 					  	
-					  	<h3><a th:href="@{/admin}" style="color:blue;">관리자 페이지</a></h3>
 					  	<h3><a th:href="@{/order/waybill}" style="color:blue;">운송장번호</a></h3>
 					  	<h3><a th:href="@{/insurance/insuranceMain}" style="color:blue;">보험메인화면</a></h3>
 					  	<h3><a th:href="@{/goods/goodsList}" style="color:blue;">상품 리스트</a></h3>
@@ -47,5 +46,5 @@
 				</div>
 			</div>
 		</section>
-	  </th:block>
+		</th:block>
 </html>


### PR DESCRIPTION
관리자 공지사항 html 부트스트랩 변경
관리자 공지사항 컨트롤러, 매퍼, 매퍼.xml에 페이징과 검색기능 추가
관리자 공지사항, FAQ 페이징 현재페이지 색상과 이전, 이후 사용하지 못할 때 색상 변경 관리자 공지사항, FAQ 리스트 너비 조절
관리자 페이지 우측상단 닉네임 삽입
관리자페이지 메인에서 삭제 후 세션아이디와 로그인레벨이 관리자가 아니면 로그인창으로 리다이렉트 만약의 사태를 대비해 로그인했는데 관리자가아니면 홈화면으로 리다이렉트
DTO Search 추가
관리자  FAQ 검색 후 페이징할 때 페이징 풀리는 오류 수정(컨트롤러에 search 생성자 생성 후 html에 뿌려줌) 관리자 공지사항 검색 후 페이징 할 때 페이징 풀리는 오류 수정(컨트롤러에 search 생성자 생성 후 html에 뿌려줌)